### PR TITLE
Bump upper bounds for `transformers` dependency

### DIFF
--- a/pipes-attoparsec.cabal
+++ b/pipes-attoparsec.cabal
@@ -33,7 +33,7 @@ library
     , pipes        (>=4.1      && <4.2)
     , pipes-parse  (>=3.0.1    && <3.1)
     , text         (>=0.11.2.0 && <1.2)
-    , transformers (>=0.2      && <0.4)
+    , transformers (>=0.2      && <0.5)
   ghc-options: -Wall -O2
 
 test-suite tests


### PR DESCRIPTION
This assumes that `pipes` and `pipes-parse` have been already bumped.
